### PR TITLE
chore: remove Az module management, rely on runner pre-installed Az

### DIFF
--- a/.github/actions/az-login/action.yml
+++ b/.github/actions/az-login/action.yml
@@ -1,5 +1,5 @@
 name: Azure Federated Credentials login
-description: Login to Azure Powershell with Federated Credentials, also installs Az.Accounts if it is not installed
+description: Login to Azure PowerShell with Federated Credentials
 inputs:
   client-id:
     required: true
@@ -20,9 +20,6 @@ runs:
         ENABLE_CLI: ${{ inputs.enable-cli }}
       shell: pwsh
       run: |
-        # Ensure Az.Accounts is up-to-date; installs if missing, updates if outdated, no-ops if current
-        Install-PSResource Az.Accounts -Scope CurrentUser -Quiet -AcceptLicense -TrustRepository
-
         # Get federated token
         $secureOIDCToken = $ENV:ACTIONS_ID_TOKEN_REQUEST_TOKEN | ConvertTo-SecureString -AsPlainText
         $federatedToken = (Invoke-RestMethod "$($ENV:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" -Authentication Bearer -Token $secureOIDCToken).value

--- a/src/Get-ResourceAliases.ps1
+++ b/src/Get-ResourceAliases.ps1
@@ -1,9 +1,6 @@
 # Abort on any error — prevents partial/empty output being committed
 $ErrorActionPreference = 'Stop'
 
-# Ensure Az.Resources is up-to-date; installs if missing, updates if outdated, no-ops if current
-Install-PSResource Az.Resources -Scope CurrentUser -Quiet -AcceptLicense -TrustRepository
-
 # Get all available policy aliases
 $resourceTypes = Get-AzPolicyAlias -ListAvailable
 $providers = $resourceTypes | Group-Object -Property Namespace


### PR DESCRIPTION
Removes all module install/update logic from both the script and login action. The `ubuntu-24.04` runner has Az pre-installed, so this is unnecessary overhead.